### PR TITLE
修复contains与match函数未生效的bug

### DIFF
--- a/pkg/cel/cel.go
+++ b/pkg/cel/cel.go
@@ -22,9 +22,8 @@ import (
 )
 
 //	判断s1是否包含s2
-var containsDec = decls.NewFunction("contains", decls.NewOverload("string_contains_string", []*exprpb.Type{decls.String, decls.String}, decls.Bool))
 var containsFunc = &functions.Overload{
-	Operator: "string_contains_string",
+	Operator: "contains_string",
 	Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 		v1, ok := lhs.(types.String)
 		if !ok {
@@ -40,7 +39,6 @@ var containsFunc = &functions.Overload{
 		return types.Bool(strings.Contains(string(v1), string(v2)))
 	},
 }
-
 
 //	判断b1 是否包含 b2
 var bcontainsDec = decls.NewFunction("bcontains", decls.NewInstanceOverload("bytes_bcontains_bytes", []*exprpb.Type{decls.Bytes, decls.Bytes}, decls.Bool))
@@ -60,9 +58,8 @@ var bcontainsFunc = &functions.Overload{
 }
 
 //	使用正则表达式s1来匹配s2
-var matchDec = decls.NewFunction("matches", decls.NewOverload("string_match_string", []*exprpb.Type{decls.String, decls.String}, decls.Bool))
 var matchFunc = &functions.Overload{
-	Operator: "string_match_string",
+	Operator: "matches_string",
 	Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
 		v1, ok := lhs.(types.String)
 		if !ok {
@@ -106,7 +103,7 @@ var bmatchFunc = &functions.Overload{
 }
 
 //	map 中是否包含某个 key，目前只有 headers 是 map[string][string] 类型
-var inDec = decls.NewFunction("in", decls.NewInstanceOverload("string_in_map_key", []*exprpb.Type{decls.String, decls.NewMapType(decls.String,decls.String)}, decls.Bool))
+var inDec = decls.NewFunction("in", decls.NewInstanceOverload("string_in_map_key", []*exprpb.Type{decls.String, decls.NewMapType(decls.String, decls.String)}, decls.Bool))
 var inFunc = &functions.Overload{
 	Operator: "string_in_map_key",
 	Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
@@ -350,7 +347,7 @@ var reverseWaitFunc = &functions.Overload{
 
 type CustomLib struct {
 	// 声明
-	envOptions     []cel.EnvOption
+	envOptions []cel.EnvOption
 	// 实现
 	programOptions []cel.ProgramOption
 }
@@ -374,7 +371,7 @@ func InitCelOptions() CustomLib {
 		),
 		// 定义
 		cel.Declarations(
-			containsDec, bcontainsDec, matchDec, bmatchDec,md5Dec,
+			bcontainsDec, bmatchDec, md5Dec,
 			//startsWithDec, endsWithDec,
 			inDec, randomIntDec, randomLowercaseDec,
 			base64StringDec, base64BytesDec, base64DecodeStringDec, base64DecodeBytesDec,
@@ -390,7 +387,7 @@ func InitCelOptions() CustomLib {
 		base64StringFunc, base64BytesFunc, base64DecodeStringFunc, base64DecodeBytesFunc,
 		urlencodeStringFunc, urlencodeBytesFunc, urldecodeStringFunc, urldecodeBytesFunc,
 		substrFunc, sleepFunc, reverseWaitFunc,
-		)}
+	)}
 	return custom
 }
 


### PR DESCRIPTION
1. contains函数已经在[这里](https://github.com/google/cel-go/blob/master/checker/standard.go#L358)声明了。，不需要再次声明。  
2. 并且生命的是 instance function，所以 Operator 应该是 contains_string。

上面两个问题导致在调用 response.reqRaw.matches("2")的函数实际上调用的是 [ func stringContains(s String, sub ref.Val) ref.Val](https://github.com/google/cel-go/blob/7d206a43b28ca86004ae0791cf874c9da7f2c44d/common/types/string.go#L199), 而不是自己定义的contains函数

同理 "abcd".matches(response.reqRaw)的函数实际上调用的是 [ func (s String) Match(pattern ref.Val) ref.Val ](https://github.com/google/cel-go/blob/7d206a43b28ca86004ae0791cf874c9da7f2c44d/common/types/string.go#L161)

并且 [ func (s String) Match(pattern ref.Val) ref.Val ](https://github.com/google/cel-go/blob/7d206a43b28ca86004ae0791cf874c9da7f2c44d/common/types/string.go#L161)与长亭poc的matches函数语义不符。
> 对于s1.matches(s2)来说，本项目最终调用的是[ func (s String) Match(pattern ref.Val) ref.Val ](https://github.com/google/cel-go/blob/7d206a43b28ca86004ae0791cf874c9da7f2c44d/common/types/string.go#L161), s1是字符串，s2是正则，而长亭的matches函数的定义是s1是正则表达式，s2是字符串。这会导致长亭开源poc执行与期望不符


长亭文档：

![image](https://user-images.githubusercontent.com/3455675/123253261-ddfd4e80-d51f-11eb-8971-67e8a1a17e8e.png)


